### PR TITLE
Added code to extract link graph from Wikipedia dumps

### DIFF
--- a/src/main/java/org/wikiclean/DumpEnWikiArticleTitles.java
+++ b/src/main/java/org/wikiclean/DumpEnWikiArticleTitles.java
@@ -59,7 +59,7 @@ public class DumpEnWikiArticleTitles {
 
     wikipedia.stream()
         .filter(page -> !page.contains("<ns>") || page.contains("<ns>0</ns>"))
-        .filter(page -> !cleaner.clean(page).replaceAll("\\n+", " ").startsWith("#REDIRECT"))
+        //.filter(page -> !cleaner.clean(page).replaceAll("\\n+", " ").startsWith("#REDIRECT"))
         .forEach(page -> {
           writer.println(cleaner.getId(page) + "\t" +
               cleaner.getTitle(page).replaceAll("\\n+", " "));

--- a/src/main/java/org/wikiclean/DumpEnWikiArticleTitles.java
+++ b/src/main/java/org/wikiclean/DumpEnWikiArticleTitles.java
@@ -37,6 +37,9 @@ public class DumpEnWikiArticleTitles {
 
     @Option(name = "-output", metaVar = "[path]", required = true, usage = "output path")
     String output;
+
+    @Option(name = "-keepRedirects", usage = "keep redirects")
+    boolean keepRedirects = false;
   }
 
   public static void main(String[] argv) throws Exception {
@@ -59,7 +62,8 @@ public class DumpEnWikiArticleTitles {
 
     wikipedia.stream()
         .filter(page -> !page.contains("<ns>") || page.contains("<ns>0</ns>"))
-        //.filter(page -> !cleaner.clean(page).replaceAll("\\n+", " ").startsWith("#REDIRECT"))
+        .filter(page -> args.keepRedirects ? true :
+            !cleaner.clean(page).replaceAll("\\n+", " ").startsWith("#REDIRECT"))
         .forEach(page -> {
           writer.println(cleaner.getId(page) + "\t" +
               cleaner.getTitle(page).replaceAll("\\n+", " "));

--- a/src/main/java/org/wikiclean/ExtractLinkGraph.java
+++ b/src/main/java/org/wikiclean/ExtractLinkGraph.java
@@ -1,0 +1,127 @@
+package org.wikiclean;
+
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.ParserProperties;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ExtractLinkGraph {
+  private static final class Args {
+    @Option(name = "-input", metaVar = "[path]", required = true, usage = "input path")
+    File input;
+
+    @Option(name = "-titles", metaVar = "[path]", required = true, usage = "article titles")
+    File titles;
+
+    @Option(name = "-output", metaVar = "[path]", required = true, usage = "output path")
+    String output;
+  }
+
+  private static final Pattern LINKS1 = Pattern.compile("\\[\\[([^\\]]+)\\|([^\\]]+)\\]\\]");
+  private static final Pattern LINKS2 = Pattern.compile("\\[\\[([^\\]]+)\\]\\]");
+
+  public static Set<Integer> extractLinks(String s, Map<String, Integer> titles) {
+    s = LINKS1.matcher(s).replaceAll("[[$1]]");
+
+    Set<String> links2 = new TreeSet<>();
+    Matcher m = LINKS2.matcher(s);
+    while (m.find()) {
+      links2.add(m.group(1));
+    }
+
+    final Set<Integer> ids = new TreeSet<>();
+    links2.forEach(target -> {
+      if (titles.containsKey(target)) {
+        ids.add(titles.get(target));
+        //System.out.println(target + " " + titles.get(target));
+      } else {
+        String initialCaps = target.substring(0, 1).toUpperCase() + target.substring(1);
+        if (titles.containsKey(initialCaps)) {
+          ids.add(titles.get(initialCaps));
+          //System.out.println(target + " " + titles.get(initialCaps));
+        } else if (target.contains("_")) {
+          String underscoresRemoved = target.replaceAll("_", " ");
+          if (titles.containsKey(underscoresRemoved)) {
+            ids.add(titles.get(underscoresRemoved));
+          } else {
+            System.out.println("ERROR! " + target);
+          }
+        } else {
+          System.out.println("ERROR! " + target);
+        }
+      }
+    });
+    //System.out.println(String.join("\n", links2));
+
+    return ids;
+  }
+
+  /**
+   * Simple program prints out all cleaned articles.
+   * @param argv command-line argument
+   * @throws Exception if any errors are encountered
+   */
+  public static void main(String[] argv) throws Exception {
+    final Args args = new Args();
+    CmdLineParser parser = new CmdLineParser(args, ParserProperties.defaults().withUsageWidth(100));
+
+    try {
+      parser.parseArgument(argv);
+    } catch (CmdLineException e) {
+      System.err.println(e.getMessage());
+      parser.printUsage(System.err);
+      System.exit(-1);
+    }
+
+    final Map<String, Integer> titles = new HashMap<>();
+    BufferedReader reader = new BufferedReader(new FileReader(args.titles));
+    String line = reader.readLine();
+    while (line != null) {
+      String arr[] = line.split("\\t");
+      //System.out.println("#" + arr[0] + "-" + arr[1]);
+      titles.put(arr[1], Integer.parseInt(arr[0]));
+      line = reader.readLine();
+    }
+    reader.close();
+    System.out.println("Number of article titles: " + titles.size());
+
+    PrintStream out = new PrintStream(System.out, true, "UTF-8");
+    PrintWriter writer = new PrintWriter(args.output, "UTF-8");
+
+    WikipediaArticlesDump wikipedia = new WikipediaArticlesDump(args.input);
+    WikiClean cleaner = new WikiClean.Builder().keepLinks().build();
+
+    AtomicInteger cnt = new AtomicInteger();
+    AtomicInteger links = new AtomicInteger();
+    wikipedia.stream()
+        // See https://en.wikipedia.org/wiki/Wikipedia:Namespace
+        .filter(s -> !s.contains("<ns>") || s.contains("<ns>0</ns>"))
+        .forEach(s -> {
+          String title = cleaner.getTitle(s);
+          String id = cleaner.getId(s);
+          out.println("### " + title + " " + id);
+          Set<Integer> ids = extractLinks(cleaner.clean(s), titles);
+          writer.println(id + "\t" + ids.stream().map(n -> n.toString()).collect(Collectors.joining("\t")));
+          cnt.incrementAndGet();
+          links.getAndAdd(ids.size());
+        });
+
+    writer.close();
+    out.println("Total of " + cnt + " nodes, " + links + " edges.");
+    out.close();
+  }
+}

--- a/src/main/java/org/wikiclean/WikiClean.java
+++ b/src/main/java/org/wikiclean/WikiClean.java
@@ -47,8 +47,16 @@ public class WikiClean {
   // Use the builder to construct.
   private WikiClean() {}
 
-  private void keepLinks() {
-    this.keepLinks = true;
+  private void setKeepLinks(boolean flag) {
+    this.keepLinks = flag;
+  }
+
+  /**
+   * Asks this cleaner whether or not links are cleaned.
+   * @return whether or not links are cleaned
+   */
+  public boolean keepLings() {
+    return keepLinks;
   }
 
   private void setWithTitle(boolean flag) {
@@ -625,6 +633,10 @@ public class WikiClean {
       return this;
     }
 
+    /**
+     * Keeps the links.
+     * @return self for method chaining
+     */
     public Builder keepLinks() {
       this.keepLinks = true;
       return this;
@@ -639,7 +651,7 @@ public class WikiClean {
       clean.setWithTitle(withTitle);
       clean.setWithFooter(withFooter);
       clean.setLanguage(lang);
-      if (keepLinks) clean.keepLinks();
+      clean.setKeepLinks(keepLinks);
 
       return clean;
     }

--- a/src/main/java/org/wikiclean/WikiClean.java
+++ b/src/main/java/org/wikiclean/WikiClean.java
@@ -42,8 +42,14 @@ public class WikiClean {
   private boolean withFooter;
   private WikiLanguage lang;
 
+  private boolean keepLinks = false;
+
   // Use the builder to construct.
   private WikiClean() {}
+
+  private void keepLinks() {
+    this.keepLinks = true;
+  }
 
   private void setWithTitle(boolean flag) {
     this.withTitle = flag;
@@ -162,7 +168,11 @@ public class WikiClean {
     content = removeEmphasis(content);
     content = removeHeadings(content);
     content = removeCategoryLinks(content);
-    content = removeLinks(content);
+
+    if (!keepLinks) {
+      content = removeLinks(content);
+    }
+
     content = removeMath(content);
     content = removeGallery(content);
     content = removeNoToc(content);
@@ -577,6 +587,7 @@ public class WikiClean {
   public static class Builder {
     private boolean withTitle = false;
     private boolean withFooter = false;
+    private boolean keepLinks = false;
     private WikiLanguage lang = WikiLanguage.EN;
 
     /**
@@ -614,6 +625,11 @@ public class WikiClean {
       return this;
     }
 
+    public Builder keepLinks() {
+      this.keepLinks = true;
+      return this;
+    }
+
     /**
      * Constructs the {@link WikiClean} instance.
      * @return the {@link WikiClean} instance
@@ -623,6 +639,7 @@ public class WikiClean {
       clean.setWithTitle(withTitle);
       clean.setWithFooter(withFooter);
       clean.setLanguage(lang);
+      if (keepLinks) clean.keepLinks();
 
       return clean;
     }


### PR DESCRIPTION
Vertices are represented by document ids, as adjacency lists (tab delimited),
e.g., src [tab] target1 [tab] target2 [tab] target3 ...

Minor changes to other bits of code - need ability to preserve redirects when dumping article titles,
and cleaner needs ability to preserve links.
