### PR TITLE
Make getWikiMarkup() more robust

### DIFF
--- a/src/main/java/org/wikiclean/WikiClean.java
+++ b/src/main/java/org/wikiclean/WikiClean.java
@@ -149,7 +149,7 @@ public class WikiClean {
     return (start == -1 || end == -1 || start > end) ? "0" : s.substring(start + 4, end);
   }
 
-  private static final String XML_START_TAG_TEXT = "<text xml:space=\"preserve\"";
+  private static final String XML_START_TAG_TEXT = "<text";
   private static final String XML_END_TAG_TEXT = "</text>";
 
   /**
@@ -160,14 +160,17 @@ public class WikiClean {
   public String getWikiMarkup(String s) {
     // parse out actual text of article
     int textStart = s.indexOf(XML_START_TAG_TEXT);
+    if (textStart >= 0) {
+      textStart = findClosingBracket(s, textStart);
+    }
     int textEnd = s.indexOf(XML_END_TAG_TEXT, textStart);
 
-    if (textStart == -1 || textStart + 27 > textEnd) {
+    if (textStart == -1 || textStart > textEnd) {
       // Returning empty string is preferable to returning null to prevent NPE.
       return "";
     }
 
-    String s2 = s.substring(textStart + 27, textEnd);
+    String s2 = s.substring(textStart, textEnd);
     if (s2.startsWith("bytes=")) {
       textEnd = s2.indexOf(">");
       s2 = s2.substring(textEnd + 1);
@@ -176,7 +179,18 @@ public class WikiClean {
     return s2;
   }
 
-  /**
+  // finds the next > in s, start searching at 'start'
+  private int findClosingBracket(String s, int start)
+  {
+	for (int i = start; i < s.length(); i++) {
+		if (s.charAt(i) == '>') {
+			return i + 1;
+		}
+	}
+	return -1;
+  }
+
+/**
    * Cleans a Wikipedia article.
    * @param page Wikipedia article
    * @return cleaned output

--- a/src/main/java/org/wikiclean/WikiClean.java
+++ b/src/main/java/org/wikiclean/WikiClean.java
@@ -161,7 +161,7 @@ public class WikiClean {
     // parse out actual text of article
     int textStart = s.indexOf(XML_START_TAG_TEXT);
     if (textStart >= 0) {
-      textStart = findClosingBracket(s, textStart);
+      textStart = s.indexOf('>', textStart) + 1;
     }
     int textEnd = s.indexOf(XML_END_TAG_TEXT, textStart);
 
@@ -170,24 +170,7 @@ public class WikiClean {
       return "";
     }
 
-    String s2 = s.substring(textStart, textEnd);
-    if (s2.startsWith("bytes=")) {
-      textEnd = s2.indexOf(">");
-      s2 = s2.substring(textEnd + 1);
-    }
-
-    return s2;
-  }
-
-  // finds the next > in s, start searching at 'start'
-  private int findClosingBracket(String s, int start)
-  {
-	for (int i = start; i < s.length(); i++) {
-		if (s.charAt(i) == '>') {
-			return i + 1;
-		}
-	}
-	return -1;
+    return s.substring(textStart, textEnd);
   }
 
 /**

--- a/src/test/java/org/wikiclean/WikiCleanDeTest.java
+++ b/src/test/java/org/wikiclean/WikiCleanDeTest.java
@@ -50,6 +50,25 @@ public class WikiCleanDeTest {
   }
 
   @Test
+  public void testId1_2020() throws Exception {
+    String raw = FileUtils.readFileToString(new File("src/test/resources/dewiki-20200801-id1.xml"), "UTF-8");
+    WikiClean cleaner = new WikiClean.Builder().withLanguage(new German()).build();
+    String content = cleaner.clean(raw);
+    //System.out.println(content);
+
+    // Make sure categories are removed properly.
+    assertFalse(content.contains("Kategorie:Pseudonym"));
+
+    // Make sure footer is removed properly.
+    assertFalse(content.contains("Referenzen"));
+    assertFalse(content.contains("Weblinks"));
+    assertFalse(content.contains("Literatur"));
+
+    assertEquals(4521, content.length());
+  }
+
+
+  @Test
   public void testId5() throws Exception {
     String raw = FileUtils.readFileToString(new File("src/test/resources/dewiki-20130602-id5.xml"), "UTF-8");
     WikiClean cleaner = new WikiClean.Builder().withLanguage(new German()).build();

--- a/src/test/resources/dewiki-20200801-id1.xml
+++ b/src/test/resources/dewiki-20200801-id1.xml
@@ -1,0 +1,82 @@
+  <page>
+    <title>Alan Smithee</title>
+    <ns>0</ns>
+    <id>1</id>
+    <revision>
+      <id>200753430</id>
+      <parentid>195875875</parentid>
+      <timestamp>2020-06-08T13:17:42Z</timestamp>
+      <contributor>
+        <username>MacOrcas</username>
+        <id>751219</id>
+      </contributor>
+      <minor />
+      <comment>unerwünschte Formatierung entfernt ([[H:TG#nicht]])</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text bytes="7667" xml:space="preserve">'''Alan Smithee''' steht als [[Pseudonym]] für einen fiktiven Regisseur, der Filme verantwortet, bei denen der eigentliche [[Regisseur]] seinen Namen nicht mit dem Werk in Verbindung gebracht haben möchte. Von 1968 bis 2000 wurde es von der [[Directors Guild of America]] (DGA) für solche Situationen empfohlen, seither ist es '''Thomas Lee'''.&lt;ref&gt;[[Los Angeles Times|latimes]].com: [http://articles.latimes.com/2000/jan/15/entertainment/ca-54271 ''Name of Director Smithee Isn't What It Used to Be''], zuletzt geprüft am 2. April 2011&lt;/ref&gt; ''Alan Smithee'' ist jedoch weiterhin in Gebrauch.
+
+Alternative Schreibweisen sind unter anderem die Ursprungsvariante ''Al'''len''' Smithee'' sowie ''Alan Sm'''y'''thee'' und ''A'''dam''' Smithee''. Auch zwei teilweise asiatisch anmutende Schreibweisen ''Alan Smi Thee'' und ''Sumishii Aran'' gehören – so die [[Internet Movie Database]] – dazu.&lt;ref name=&quot;IMDb&quot;&gt;[http://www.imdb.com/name/nm0000647/ Eigener Eintrag für ''Alan Smithee'' in der IMDb]&lt;/ref&gt;
+
+== Geschichte ==
+=== Entstehung ===
+Das Pseudonym entstand 1968 infolge der Arbeiten am Western-Film ''Death of a Gunfighter'' (deutscher Titel ''[[Frank Patch – Deine Stunden sind gezählt]]''). Regisseur [[Robert Totten]] und Hauptdarsteller [[Richard Widmark]] gerieten in einen Streit, woraufhin [[Don Siegel]] als neuer Regisseur eingesetzt wurde.
+
+Der Film trug nach Abschluss der Arbeiten noch deutlich Tottens [[Manier (Stil)|Handschrift]], der auch mehr Drehtage als Siegel daran gearbeitet hatte, weshalb dieser die Nennung seines Namens als Regisseur ablehnte. Totten selbst lehnte aber ebenfalls ab. Als Lösung wurde  ''Allen Smithee'' als ein möglichst einzigartiger Name gewählt.&lt;ref&gt;[http://www.imdb.com/name/nm0000647/bio ''Biography for Alan Smithee''] in der Internet Movie Database&lt;/ref&gt;
+
+In den zeitgenössischen Kritiken wurde der Regisseur u.&amp;nbsp;a. von [[Roger Ebert]] mit den Worten gelobt: {{Zitat-en|Director Allen Smithee, a name I’m not familiar with, allows his story to unfold naturally. He never preaches, and he never lingers on the obvious. His characters do what they have to do.&lt;ref&gt;rogerebert.[[Chicago Sun-Times|suntimes]].com: [https://www.rogerebert.com/reviews/death-of-a-gunfighter-1969 ''Death of a Gunfighter''], zuletzt geprüft am 2. April 2011&lt;/ref&gt;|Übersetzung=Regisseur Alan Smithee, ein Name, der mir nicht vertraut ist, erlaubt es seiner Handlung, sich natürlich zu entfalten. Er predigt niemals, und er verweilt nie beim Offensichtlichen. Seine Charaktere tun, was sie tun müssen.}}
+
+=== Aufdeckung und Abkehr ===
+1997 kam die Parodie ''An Alan Smithee Film: Burn Hollywood Burn'' (deutscher Titel ''[[Fahr zur Hölle Hollywood]]'') in die Kinos, was das Pseudonym einem größeren Publikum bekannt machte, nicht zuletzt weil [[Arthur Hiller (Regisseur)|Arthur Hiller]], der eigentliche Regisseur des Films, selbst seinen Namen zurückzog und analog zum Filmtitel das Pseudonym ''Alan Smithee'' benutzte. Der Film gilt als einer der schlechtesten Filme der 1990er Jahre und gewann fünf [[Goldene Himbeere]]n.
+
+Der Film ''[[Supernova (2000)|Supernova]]'' ist der erste Post-Smithee-Film, dort führte ein gewisser ''Thomas Lee'' alias [[Walter Hill]] die Regie.
+&lt;!-- fand nur einen für den von 1990, siehe ''[[Das Kindermädchen]]'':
+„Smithee wurde allerdings auch nach ''Supernova'' gesichtet, in einem Film namens ''The Guardian''.“
+--&gt;
+
+== Verwendung ==
+Die Verwendung dieses oder eines anderen Pseudonyms ist für Mitglieder der DGA streng reglementiert. Ein Regisseur, der für einen von ihm gedrehten Film seinen Namen nicht hergeben möchte, hat nach Sichtung des fertigen Films drei Tage Zeit, anzuzeigen, dass er ein Pseudonym verwenden möchte. Der Rat der DGA entscheidet binnen zwei Tagen über das Anliegen. Erhebt die Produktionsfirma Einspruch, entscheidet ein Komitee aus Mitgliedern der DGA und der Vereinigung der Film- und Fernsehproduzenten, ob der Regisseur ein Pseudonym angeben darf. Über die Beantragung muss der Regisseur Stillschweigen halten, ebenso darf er den fertigen Film nicht öffentlich kritisieren, wenn die DGA ihm die Verwendung eines Pseudonyms zugesteht.&lt;ref&gt;Siehe zu diesen Regelungen [http://www.dga.org/~/media/Files/Contracts/Agreements/2008%20BA/008ba2008article8.pdf Artikel 8, Abschnitt 8-211 des ''Basic Agreement''] (PDF; 125&amp;nbsp;kB) der DGA von 2008, abgerufen am 25. April 2012&lt;/ref&gt; Ein Antrag des Regisseurs auf Pseudonymisierung kann abgelehnt werden, so durfte [[Tony Kaye (Regisseur)|Tony Kaye]] den Namen Smithee bei dem Film ''[[American History X]]'' nicht einsetzen, obwohl er den Antrag stellte.
+
+Auch bei nicht-US-amerikanischen Produktionen wird der Name verwendet, wie etwa beim [[Pilotfilm]] der Fernsehserie ''[[Schulmädchen (Fernsehserie)|Schulmädchen]]''. 2007 sendete die ARD am 8. und 9. August den zweiteiligen TV-Film ''Paparazzo''. Auch in diesem Werk erscheint anstatt des eigentlichen Regisseurs [[Stephan Wagner (Regisseur)|Stephan Wagner]] Alan Smithee im Abspann.
+
+Regisseure, die das Pseudonym benutzt haben:
+* [[Don Siegel]] und [[Robert Totten]] (für ''[[Frank Patch – Deine Stunden sind gezählt]]'')
+* [[David Lynch]] (für die dreistündige Fernsehfassung von ''[[Der Wüstenplanet (Film)|Der Wüstenplanet]]'')
+* [[Chris Christensen]] (''The Omega Imperative'')
+* [[Gianni Bozzacchi]] (für ''I Love N.Y.'')
+* [[Stuart Rosenberg]] (für ''Let’s Get Harry'')
+* [[Richard C. Sarafian]] (für ''[[Starfire]]'')
+* [[Dennis Hopper]] (für ''[[Catchfire]]'')
+* [[Arthur Hiller (Regisseur)|Arthur Hiller]] (für ''[[Fahr zur Hölle Hollywood]]'')
+* [[Rick Rosenthal]] (''Die Vögel II – Die Rückkehr'')
+* [[Kevin Yagher]] (''[[Hellraiser IV – Bloodline]]'')
+
+Der Pilotfilm der Serie ''[[MacGyver]]'' und die fünfte Folge der ersten Staffel führen einen Alan Smithee als Regisseur. Auf der TV-Serien-Seite ''TV Rage'' wird Jerrold Freedman als Regisseur des Pilotfilms angegeben. Der Regisseur der fünften Folge ist unbekannt.
+
+Zu den Drehbuchautoren, die das Pseudonym benutzt haben, gehören [[Sam Raimi]] und [[Ivan Raimi]], die das Drehbuch zu ''Die total beknackte Nuß'' als ''Alan Smithee, Jr.'' und ''Alan Smithee, Sr.'' schrieben.
+
+Auch in Computerspielen wird dieses Pseudonym angegeben: Im Abspann des Ego-Shooters ''Marine Sharpshooter IV'' aus dem Jahr 2008 wird als Art Director des Spiels ''Alan Smithee'' genannt.&lt;ref&gt;http://einestages.spiegel.de/external/ShowTopicAlbumBackground/a13641/l26/l0/F.html#featuredEntry&lt;/ref&gt;
+
+2014 produzierte die [[New York City|New Yorker]] Performance-Kompanie [[Big Dance Theater]] ''Alan Smithee Directed this Play'', das im August des Jahres auch in Berlin bei [[Tanz im August]] aufgeführt wurde.&lt;ref&gt;''Alan Smithee ist schuld!'' in [[Frankfurter Allgemeine Sonntagszeitung]] vom 17. August 2014, Seite 36&lt;/ref&gt;
+
+== Literatur ==
+* Jeremy Braddock, Stephen Hock (Hrsg.): ''Directed by Allen Smithee.'' Foreword by Andrew Sarris. University of Minnesota Press, Minneapolis, London 2001, ISBN 0-8166-3534-X.
+
+== Weblinks ==
+* {{IMDb|nm0000647}}
+* [http://www.abc.net.au/rn/arts/atoday/stories/s353584.htm Artikel über Smithee von ABC Online (englisch)]
+* [http://einestages.spiegel.de/static/topicalbumbackground/13641/der_mann_der_niemals_lebte.html Der Mann, der niemals lebte, Spiegel Online einestages]
+* [http://dradiowissen.de/beitrag/alan-smithee-die-film-legende-lebt Alan Smithee lebt!, DRadio Wissen]
+
+== Einzelnachweise ==
+&lt;references /&gt;
+
+{{Normdaten|TYP=p|GND=123396956|VIAF=86737339}}
+
+[[Kategorie:Fiktive Person|Smithee, Alan]]
+[[Kategorie:Pseudonym]]
+[[Kategorie:Sammelpseudonym|Smithee, Alan]]
+[[Kategorie:Werk von Alan Smithee]]</text>
+      <sha1>6pqxfu8jh46bwo11ztavorcv4dabah1</sha1>
+    </revision>
+  </page>


### PR DESCRIPTION
I've been looking into using your library and trying things on a recent Wikipedia dump, it didn't work.

Turns out that

    <text xml:space="preserve">

looked like this there:

    <text bytes="57805" xml:space="preserve">

So I made the code that looks for the start of the actual wiki text a bit more robust by starting at `<text ` and then seeking forward to the next `>`.