### PR TITLE
Add method WikiClean#cleanContent() and improve Javadoc

### DIFF
--- a/src/main/java/org/wikiclean/WikiClean.java
+++ b/src/main/java/org/wikiclean/WikiClean.java
@@ -178,12 +178,27 @@ public class WikiClean {
 
   /**
    * Cleans a Wikipedia article.
-   * @param page Wikipedia article
+   * @param page Wikipedia article contained in XML such as <page>....</page>
    * @return cleaned output
    */
   public String clean(String page) {
     String content = getWikiMarkup(page);
 
+    String cleaned = cleanContent(content);
+
+    if (withTitle) {
+      return getTitle(page) + "\n\n" + cleaned.trim();
+    }
+
+    return cleaned.trim();
+  }
+
+  /**
+   * Cleans a Wikipedia article.
+   * @param content Wikipedia article content (the Wikitext markup)
+   * @return cleaned output
+   */
+  public String cleanContent(String content) {
     if (!withFooter) {
       content = removeFooter(content);
     }
@@ -216,10 +231,6 @@ public class WikiClean {
 
     // Finally, fold multiple newlines.
     content = compressMultipleNewlines(content);
-
-    if (withTitle) {
-      return getTitle(page) + "\n\n" + content.trim();
-    }
 
     return content.trim();
   }


### PR DESCRIPTION
I added a method `cleanContent()` which accepts Wikitext directly. It makes sense if for some reason the user of the library does not have a snippet of Mediawiki wrapped inside dump xml but has a piece Wikitext that they want to parse using the library.